### PR TITLE
use correct syntax for environment variables in CF/CodeBuild

### DIFF
--- a/CodeAfterExercise4/pipeline/pipeline-template.yml
+++ b/CodeAfterExercise4/pipeline/pipeline-template.yml
@@ -277,7 +277,8 @@ Resources:
         PrivilegedMode: false
         Type: LINUX_CONTAINER
         EnvironmentVariables:
-          - SOURCE_BUCKET_NAME: !Ref SourceBucketName
+          - Name: SOURCE_BUCKET_NAME
+            Value: !Ref SourceBucketName
       ServiceRole:
         Fn::GetAtt:
           - BuildProjectRole

--- a/WORKSHEET.md
+++ b/WORKSHEET.md
@@ -1213,7 +1213,8 @@ Resources:
         PrivilegedMode: false
         Type: LINUX_CONTAINER
         EnvironmentVariables:
-          - SOURCE_BUCKET_NAME: !Ref SourceBucketName
+          - Name: SOURCE_BUCKET_NAME
+            Value: !Ref SourceBucketName
       ServiceRole:
         Fn::GetAtt:
           - BuildProjectRole


### PR DESCRIPTION
CodeBuild fails due to syntax of using the environment variables.

This switches to using Name/Value as per 
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-environment.html
and
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-environmentvariable.html

